### PR TITLE
Changes for profiling

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -272,7 +272,11 @@ let overrideCabal = pkg: f: if pkg == null then null else haskellLib.overrideCab
         ########################################################################
         reflex = addFastWeakFlag (addReflexTraceEventsFlag (addReflexOptimizerFlag (self.callPackage (hackGet ./reflex) {})));
         reflex-dom = addReflexOptimizerFlag (doJailbreak reflexDom.reflex-dom);
-        reflex-dom-core = addReflexOptimizerFlag (doJailbreak reflexDom.reflex-dom-core);
+        reflex-dom-core = let
+            # From newer nixpkgs. When focus is finally bumped will go away.
+            appendConfigureFlags = drv: xs: overrideCabal drv (drv: { configureFlags = (drv.configureFlags or []) ++ xs; });
+          in appendConfigureFlags (addReflexOptimizerFlag (doJailbreak reflexDom.reflex-dom-core))
+                                  (optional enableLibraryProfiling "-fprofile-reflex");
         reflex-todomvc = self.callPackage (hackGet ./reflex-todomvc) {};
         reflex-aeson-orphans = self.callPackage (hackGet ./reflex-aeson-orphans) {};
         haven = self.callHackage "haven" "0.2.0.0" {};

--- a/jsaddle/github.json
+++ b/jsaddle/github.json
@@ -1,6 +1,6 @@
 {
   "owner": "wrinkl",
   "repo": "jsaddle",
-  "rev": "a28f95ddac3e5c694cd2cd08cd96e14ff45ee49c",
-  "sha256": "11ih1g31xhm34blb20nyylwpbfjhb02fd3c4vk47w54a95pjf7p4"
+  "rev": "0027ef5558a97b8f23e44967b79bf135a447f0d0",
+  "sha256": "0lg60xicfyd529kglg2vy882g4ivkdqc62szvdw4a87xhkbvbh4i"
 }

--- a/reflex-dom/github.json
+++ b/reflex-dom/github.json
@@ -1,6 +1,6 @@
 {
   "owner": "reflex-frp",
   "repo": "reflex-dom",
-  "rev": "df9fff3a0f4e393db6af0beecabd38156c82aedc",
-  "sha256": "04zb388xdiarpilr0q0b3pb34h6dycr7y0jgrb3q4zx4dbksq7br"
+  "rev": "d81c8e263824d1ff28adaedecb37fecdad393214",
+  "sha256": "02chw27vm8ilhgckc0njrlprfksaph64q3dxpswn16nyg3y2zjsk"
 }

--- a/reflex/github.json
+++ b/reflex/github.json
@@ -1,6 +1,6 @@
 {
   "owner": "reflex-frp",
   "repo": "reflex",
-  "rev": "9f3356fecb1620f74b45291b38aaaafbe92458fa",
-  "sha256": "0myyla3frfymig6bwip3n54z85r1kai65b0spw0pldxvrhg4k4xc"
+  "rev": "d49708dba2eabb2635d6f774a30802d9378e1c24",
+  "sha256": "1q8dnknd9sypim3m3nk60hyfb0hcb3dccx4mjvqwkpx9827zkwc6"
 }


### PR DESCRIPTION
> Bump reflex, reflex-dom, and jsaddle to PR branches
> 
> Each fix is needed for profiling builds.`
> 
> PRs for Reflex and Reflex DOM are based off of the old commits for
convenience, and thankfully still have no conflicts with develop.
JSaddle's is a backport of a merged PR.

> Enable the Reflex profiler in all profiled builds
>
> (cherry picked from commit 2903bfa)